### PR TITLE
Ability to specify filter and function stubs via command line, and more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_script:
 php:
   - 5.3
   - 5.4
-
+  - 7.0

--- a/README.md
+++ b/README.md
@@ -92,3 +92,16 @@ Now you may add your custom extensions [here](https://github.com/umpirsky/Twig-G
 $twig->addFunction(new \Twig_SimpleFunction('myCustomExtension', true));
 $twig->addFunction(new \Twig_SimpleFunction('myCustomExtension2', true));
 ```
+
+## Command Line Arguments
+
+You can also specify custom extensions and filters via command line, by adding the --functions and --filters arguments, e.g.:
+```
+--functions formRow,formElement --filters localizedCurrency
+``` 
+
+You can specify an unlimited amount of comma-separated function and filter names.
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,23 +1,34 @@
-Twig Gettext Extractor [![Build Status](https://secure.travis-ci.org/umpirsky/Twig-Gettext-Extractor.png?branch=master)](http://travis-ci.org/umpirsky/Twig-Gettext-Extractor)
+Twig Gettext Extractor
 ======================
 
-The Twig Gettext Extractor is [Poedit](http://www.poedit.net/download.php)
-friendly tool which extracts translations from twig templates.
+This Twig Gettext Extractor is a fork with some love put in; things I needed to develop an alternative to Poedit that
+on OS X is a major pain with all of the temp folder issues.
+
+This tool, gives you what you need to extract *.po files from your Twig files, and additionally:
+
+* supports text domains
+* supports command-line stubs for functions
+* supports command-line stubs for filters
 
 ## Installation
 
-The recommended way to install Twig Gettext Extractor is through
-[composer](http://getcomposer.org).
+Install this through composer [composer](http://getcomposer.org).
 
 ```json
 {
     "require": {
-        "umpirsky/twig-gettext-extractor": "1.1.*"
+        "saeven/circlical-twig-extractor": "*"
     }
 }
 ```
+## Web-Based Editing for Zend Framework 2
 
-## Setup
+You can skip this setup though, and use my web-based editor for ZF2.
+[Click here for more info](https://packagist.org/packages/saeven/zf2-poeditor)
+
+When the time comes, I'll PSR-7 it to make it framework-agnostic.
+
+## PoEdit Setup
 
 By default, Poedit does not have the ability to parse Twig templates.
 This can be resolved by adding an additional parser (Edit > Preferences > Parsers)
@@ -33,8 +44,7 @@ with the following options:
 
 <img src="http://i.imgur.com/f9px2.png" />
 
-Now you can update your catalog and Poedit will synchronize it with your twig
-templates.
+Now you can update your catalog and Poedit will synchronize it with your twig templates.
 
 ## Custom extensions
 
@@ -57,4 +67,4 @@ To run the test suite, you need [composer](http://getcomposer.org) and
 
 ## License
 
-Twig Gettext Extractor is licensed under the MIT license.
+Twig Gettext Extractor is licensed under the MIT license, like its parent fork.

--- a/Twig/Gettext/Extractor.php
+++ b/Twig/Gettext/Extractor.php
@@ -39,6 +39,25 @@ class Extractor
      */
     protected $parameters;
 
+
+    protected $executable;
+
+    /**
+     * @return mixed
+     */
+    public function getExecutable()
+    {
+        return $this->executable;
+    }
+
+    /**
+     * @param mixed $executable
+     */
+    public function setExecutable( $executable )
+    {
+        $this->executable = $executable;
+    }
+
     public function __construct(\Twig_Environment $environment)
     {
         $this->environment = $environment;
@@ -69,7 +88,11 @@ class Extractor
 
     public function extract()
     {
-        $command = 'xgettext';
+        error_reporting( E_ALL );
+        ini_set( 'display_errors', 'On' );
+
+
+        $command = $this->executable ?: 'xgettext';
         $command .= ' '.join(' ', $this->parameters);
         $command .= ' '.join(' ', $this->templates);
 

--- a/Twig/Gettext/Extractor.php
+++ b/Twig/Gettext/Extractor.php
@@ -32,15 +32,26 @@ class Extractor
      */
     protected $parameters;
 
+
+    private $executable;
+
     public function __construct(\Twig_Environment $environment)
     {
         $this->environment = $environment;
         $this->reset();
     }
 
+    /**
+     * @param mixed $executable
+     */
+    public function setExecutable($executable)
+    {
+        $this->executable = $executable;
+    }
+
     protected function reset()
     {
-        $this->parameters = array();
+        $this->parameters = [];
     }
 
     public function addTemplate($path)
@@ -60,8 +71,8 @@ class Extractor
 
     public function extract()
     {
-        $command = 'xgettext';
-        $command .= ' '.implode(' ', $this->parameters);
+        $command = $this->executable ?: 'xgettext';
+        $command .= ' ' . implode(' ', $this->parameters);
         $command .= ' ' . $this->environment->getCache() . '/*/*.php';
 
         $error = 0;

--- a/Twig/Gettext/Test/ExtractorTest.php
+++ b/Twig/Gettext/Test/ExtractorTest.php
@@ -32,12 +32,12 @@ class ExtractorTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $filesystem = new Filesystem('/', __DIR__.'/Fixtures/twig');
-        $filesystem->prependPath(__DIR__.'/Fixtures/twig');
-        $this->twig = new \Twig_Environment($filesystem, array(
-            'cache' => '/tmp/cache/'.uniqid(),
+        $filesystem = new Filesystem('/', __DIR__ . '/Fixtures/twig');
+        $filesystem->prependPath(__DIR__ . '/Fixtures/twig');
+        $this->twig = new \Twig_Environment($filesystem, [
+            'cache' => '/tmp/cache/' . uniqid(),
             'auto_reload' => true,
-        ));
+        ]);
         $this->twig->addExtension(new \Twig_Extensions_Extension_I18n());
 
         $this->loader = new PoFileLoader();
@@ -71,21 +71,21 @@ class ExtractorTest extends \PHPUnit\Framework\TestCase
 
     public function extractDataProvider()
     {
-        return array(
-            array(
-                array(
+        return [
+            [
+                [
                     '/singular.twig',
                     '/plural.twig',
-                ),
+                ],
                 $this->getGettextParameters(),
-                array(
+                [
                     'Hello %name%!',
                     'Hello World!',
                     'Hey %name%, I have one apple.',
                     'Hey %name%, I have %count% apples.',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     public function testExtractNoTranslations()
@@ -104,16 +104,27 @@ class ExtractorTest extends \PHPUnit\Framework\TestCase
 
     private function getPotFile()
     {
-        return __DIR__.'/Fixtures/messages.pot';
+        return __DIR__ . '/Fixtures/messages.pot';
     }
 
     private function getGettextParameters()
     {
-        return array(
+        return [
             '--force-po',
             '-o',
             $this->getPotFile(),
-        );
+        ];
+    }
+
+    public function testExtractWithCustomStubs()
+    {
+        $extractor = new Extractor($this->twig);
+        $this->twig->addFunction(new \Twig_SimpleFunction('serverUrl', true));
+        $this->twig->addFunction(new \Twig_SimpleFunction('url', true));
+        $this->twig->addFunction(new \Twig_SimpleFunction('1', true));
+        $extractor->addTemplate(__DIR__ . '/Fixtures/twig/customFunctions.twig');
+        $extractor->setGettextParameters($this->getGettextParameters());
+        $extractor->extract();
     }
 
     protected function tearDown()
@@ -122,4 +133,5 @@ class ExtractorTest extends \PHPUnit\Framework\TestCase
             unlink($this->getPotFile());
         }
     }
+
 }

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
-    "name": "umpirsky/twig-gettext-extractor",
+    "name": "saeven/cirlical-twig-extractor",
     "type": "application",
-    "description": "The Twig Gettext Extractor is Poedit friendly tool which extracts translations from twig templates.",
+    "description": "The Twig Gettext Extractor is Poedit friendly tool which extracts translations from twig templates. This fork from the original has been modified to support saeven/circlical-twig-trans, which adds text domain support to the trans extension.",
     "license": "MIT",
     "authors": [
         {
-            "name": "Саша Стаменковић",
-            "email": "umpirsky@gmail.com"
+            "name": "Alexandre Lemaire",
+            "email": "alemaire@circlical.com"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "symfony/routing":     ">=2.0,<3.0",
         "symfony/filesystem":  ">=2.0,<3.0",
         "symfony/translation": ">=2.0,<3.0",
-        "symfony/form":        ">=2.0,<3.0"
+        "symfony/form":        ">=2.0,<3.0",
+        "saeven/zf2-circlical-trans": "dev-master"
     },
     "require-dev": {
         "symfony/config":      "2.1.*"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "saeven/cirlical-twig-extractor",
+    "name": "saeven/circlical-twig-extractor",
     "type": "application",
     "description": "The Twig Gettext Extractor is Poedit friendly tool which extracts translations from twig templates. This fork from the original has been modified to support saeven/circlical-twig-trans, which adds text domain support to the trans extension.",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/filesystem":  ">=2.0,<3.0",
         "symfony/translation": ">=2.0,<3.0",
         "symfony/form":        ">=2.0,<3.0",
-        "saeven/zf2-circlical-trans": "dev-master"
+        "saeven/zf2-circlical-trans": "*"
     },
     "require-dev": {
         "symfony/config": "2.1.*",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "saeven/circlical-twig-extractor",
     "type": "application",
-    "description": "The Twig Gettext Extractor is Poedit friendly tool which extracts translations from twig templates. This fork from the original has been modified to support saeven/zf2-circlical-trans, which adds text domain support to the trans extension.",
+    "description": "The Twig Gettext Extractor is Poedit friendly tool which extracts translations from Twig templates. This fork from the original has been modified to support saeven/zf2-circlical-trans, which adds text domain support to the trans extension.",
     "license": "MIT",
     "authors": [
         {
@@ -13,6 +13,7 @@
         "php":                 ">=5.3.3",
         "twig/twig":           ">=1.2.0,<2.0-dev",
         "twig/extensions":     ">=1.0,<2.0",
+        "zendframework/zend-view": "@stable",
         "symfony/twig-bridge": ">=2.0,<3.0",
         "symfony/routing":     ">=2.0,<3.0",
         "symfony/filesystem":  ">=2.0,<3.0",
@@ -21,7 +22,8 @@
         "saeven/zf2-circlical-trans": "dev-master"
     },
     "require-dev": {
-        "symfony/config":      "2.1.*"
+        "symfony/config": "2.1.*",
+		"phpspec/phpspec": "@stable"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "saeven/circlical-twig-extractor",
     "type": "application",
-    "description": "The Twig Gettext Extractor is Poedit friendly tool which extracts translations from twig templates. This fork from the original has been modified to support saeven/circlical-twig-trans, which adds text domain support to the trans extension.",
+    "description": "The Twig Gettext Extractor is Poedit friendly tool which extracts translations from twig templates. This fork from the original has been modified to support saeven/zf2-circlical-trans, which adds text domain support to the trans extension.",
     "license": "MIT",
     "authors": [
         {

--- a/twig-gettext-extractor
+++ b/twig-gettext-extractor
@@ -63,14 +63,21 @@ $twig->addFunction(new \Twig_SimpleFunction('formInput', true));
 $twig->addFunction(new \Twig_SimpleFunction('formElementErrors', true));
 $twig->addFunction(new \Twig_SimpleFunction('formCaptcha', true));
 $twig->addFunction(new \Twig_SimpleFunction('formHidden', true));
+$twig->addFunction(new \Twig_SimpleFunction('formSelect', true));
 $twig->addFunction(new \Twig_SimpleFunction('doctype', true));
 $twig->addFunction(new \Twig_SimpleFunction('headTitle', true));
 $twig->addFunction(new \Twig_SimpleFunction('headMeta', true));
-$twig->addFunction(new \Twig_SimpleFunction('headLink', true));
+$twig->addFunction(new \Twig_SimpleFunction('headStyle', true));
 $twig->addFunction(new \Twig_SimpleFunction('headScript', true));
+$twig->addFunction(new \Twig_SimpleFunction('headLink', true));
 $twig->addFunction(new \Twig_SimpleFunction('OptIn', true));
 $twig->addFunction(new \Twig_SimpleFunction('InviteEmailHeader', true));
 $twig->addFunction(new \Twig_SimpleFunction('InviteEmailFooter', true));
+$twig->addFunction(new \Twig_SimpleFunction('inlineScript', true));
+$twig->addFunction(new \Twig_SimpleFunction('EmeButtonMenu', true));
+$twig->addFunction(new \Twig_SimpleFunction('layout', true));
+$twig->addFunction(new \Twig_SimpleFunction('recaptcha', true));
+
 
 
 array_shift($_SERVER['argv']);

--- a/twig-gettext-extractor
+++ b/twig-gettext-extractor
@@ -2,8 +2,13 @@
 <?php
 
 /**
- * This file is part of the Twig Gettext utility.
- *
+ * Fork from umpirsky's gettext extractor.  Modified to support
+ * custom trans extension that supports domains.
+ * 
+ *  Modification:
+ *  Alexandre Lemaire <alemaire@circlical.com>
+ * 
+ *  Original work:
  *  (c) Саша Стаменковић <umpirsky@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -26,10 +31,23 @@ $twig = new Twig_Environment(new Twig\Gettext\Loader\Filesystem('/'), array(
     'cache'       => '/tmp/cache/'.uniqid(),
     'auto_reload' => true
 ));
+
 $twig->addExtension(new Symfony\Bridge\Twig\Extension\TranslationExtension(
     new Symfony\Component\Translation\Translator(null)
 ));
-$twig->addExtension(new Twig_Extensions_Extension_I18n());
+
+$chain    = new Twig_Loader_Chain( [] );
+$renderer = new ZfcTwig\View\TwigRenderer(
+    new Zend\View\View, 
+    $chain, 
+    $twig, 
+    new ZfcTwig\View\TwigResolver($twig)
+);
+
+$trans    = new CirclicalTwigTrans\Model\Twig\Trans( $renderer );
+
+$twig->addExtension( $trans );
+
 $twig->addExtension(new Symfony\Bridge\Twig\Extension\RoutingExtension(
     new Twig\Gettext\Routing\Generator\UrlGenerator()
 ));
@@ -38,6 +56,7 @@ $twig->addExtension(new Symfony\Bridge\Twig\Extension\FormExtension(
         new Symfony\Bridge\Twig\Form\TwigRendererEngine()
     )
 ));
+
 // You can add more extensions here.
 $twig->addFunction(new \Twig_SimpleFunction('formLabel', true));
 $twig->addFunction(new \Twig_SimpleFunction('formInput', true));
@@ -50,6 +69,7 @@ $twig->addFunction(new \Twig_SimpleFunction('headMeta', true));
 $twig->addFunction(new \Twig_SimpleFunction('headLink', true));
 $twig->addFunction(new \Twig_SimpleFunction('headScript', true));
 $twig->addFunction(new \Twig_SimpleFunction('OptIn', true));
+
 
 array_shift($_SERVER['argv']);
 $addTemplate = false;

--- a/twig-gettext-extractor
+++ b/twig-gettext-extractor
@@ -16,16 +16,16 @@
  * @author Саша Стаменковић <umpirsky@gmail.com>
  */
 
-if (file_exists($a = __DIR__.'/../../autoload.php')) {
+if (file_exists($a = __DIR__ . '/../../autoload.php')) {
     require_once $a;
 } else {
-    require_once __DIR__.'/vendor/autoload.php';
+    require_once __DIR__ . '/vendor/autoload.php';
 }
 
-$twig = new Twig_Environment(new Twig\Gettext\Loader\Filesystem(DIRECTORY_SEPARATOR), array(
-    'cache'       => implode(DIRECTORY_SEPARATOR, array(sys_get_temp_dir(), 'cache', uniqid()) ),
-    'auto_reload' => true
-));
+$twig = new Twig_Environment(new Twig\Gettext\Loader\Filesystem(DIRECTORY_SEPARATOR), [
+    'cache' => implode(DIRECTORY_SEPARATOR, [sys_get_temp_dir(), 'cache', uniqid()]),
+    'auto_reload' => true,
+]);
 $twig->addExtension(new Twig_Extensions_Extension_I18n());
 $twig->addExtension(new Symfony\Bridge\Twig\Extension\TranslationExtension(
     new Symfony\Component\Translation\Translator(null)
@@ -38,21 +38,58 @@ $twig->addExtension(new Symfony\Bridge\Twig\Extension\FormExtension(
         new Symfony\Bridge\Twig\Form\TwigRendererEngine()
     )
 ));
-$twig->addExtension(new Symfony\Bridge\Twig\Extension\AssetExtension( 
+$twig->addExtension(new Symfony\Bridge\Twig\Extension\AssetExtension(
     new Symfony\Component\Asset\Packages()
 ));
-// You can add more extensions here.
+
+// You can add more extensions here, or via command line with the --functions and --filter options
 
 array_shift($_SERVER['argv']);
+
+$setFunctions = false;
+$setFilters = false;
+foreach ($_SERVER['argv'] as $arg) {
+    if ('--functions' === $arg) {
+        $setFunctions = true;
+    } else if ($setFunctions) {
+        foreach (explode(',', $arg) as $functionName) {
+            $twig->addFunction(new \Twig_SimpleFunction($functionName, true));
+        }
+        $setFunctions = false;
+    } else if ('--filters' === $arg) {
+        $setFilters = true;
+    } else if ($setFilters) {
+        foreach (explode(',', $arg) as $filterName) {
+            $twig->addFilter(new \Twig_SimpleFilter($filterName, true));
+        }
+        $setFilters = false;
+    }
+}
+
+
 $addTemplate = false;
+$setExecutable = false;
 
 $extractor = new Twig\Gettext\Extractor($twig);
 
 foreach ($_SERVER['argv'] as $arg) {
-    if ('--files' == $arg) {
+    if ('--files' === $arg) {
         $addTemplate = true;
     } else if ($addTemplate) {
-        $extractor->addTemplate(getcwd().DIRECTORY_SEPARATOR.$arg);
+        $extractor->addTemplate(getcwd() . DIRECTORY_SEPARATOR . $arg);
+    } else if ('--exec' === $arg) {
+        $setExecutable = true;
+    } else if ($setExecutable) {
+        $extractor->setExecutable($arg);
+        $setExecutable = false;
+    } else if ('--functions' === $arg) {
+        $setFunctions = true;
+    } else if ($setFunctions) {
+        $setFunctions = false;
+    } else if ('--filters' === $arg) {
+        $setFilters = true;
+    } else if ($setFilters) {
+        $setFilters = false;
     } else {
         $extractor->addGettextParameter($arg);
     }

--- a/twig-gettext-extractor
+++ b/twig-gettext-extractor
@@ -58,23 +58,16 @@ $twig->addExtension(new Symfony\Bridge\Twig\Extension\FormExtension(
 ));
 
 // You can add more extensions here.
-$twig->addFunction(new \Twig_SimpleFunction('formLabel', true));
-$twig->addFunction(new \Twig_SimpleFunction('formInput', true));
-$twig->addFunction(new \Twig_SimpleFunction('formElementErrors', true));
-$twig->addFunction(new \Twig_SimpleFunction('formCaptcha', true));
-$twig->addFunction(new \Twig_SimpleFunction('formHidden', true));
-$twig->addFunction(new \Twig_SimpleFunction('formSelect', true));
-$twig->addFunction(new \Twig_SimpleFunction('doctype', true));
-$twig->addFunction(new \Twig_SimpleFunction('headTitle', true));
-$twig->addFunction(new \Twig_SimpleFunction('headMeta', true));
-$twig->addFunction(new \Twig_SimpleFunction('headStyle', true));
-$twig->addFunction(new \Twig_SimpleFunction('headScript', true));
-$twig->addFunction(new \Twig_SimpleFunction('headLink', true));
-$twig->addFunction(new \Twig_SimpleFunction('inlineScript', true));
-$twig->addFunction(new \Twig_SimpleFunction('layout', true));
-$twig->addFunction(new \Twig_SimpleFunction('recaptcha', true));
+$default_stub_functions = [
+    'formLabel', 'formInput', 'formElementErrors', 'formCaptcha', 'formHidden', 'formSelect', 'doctype',
+    'headTitle', 'headMeta', 'headStyle', 'headScript', 'headLink', 'inlineScript', 'layout',  'recaptcha',
+];
+
+foreach( $default_stub_functions as $f )
+    $twig->addFunction(new \Twig_SimpleFunction($f, true));
 
 $setFunctions = false;
+$setFilters   = false;
 array_shift($_SERVER['argv']);
 foreach ($_SERVER['argv'] as $arg)
 {
@@ -88,9 +81,17 @@ foreach ($_SERVER['argv'] as $arg)
             $twig->addFunction(new \Twig_SimpleFunction($fn,true));
 	    $setFunctions = false;
     }
+    else if( "--filters" == $arg )
+    {
+        $setFilters = true;
+    }
+    else if( $setFilters )
+    {
+        foreach( explode(",", $arg ) as $fn )
+            $twig->addFilter(new \Twig_SimpleFilter($fn,true));
+	    $setFilters = false;
+    }
 }
-
-
 
 
 $addTemplate = false;
@@ -123,6 +124,14 @@ foreach ($_SERVER['argv'] as $arg)
     else if( $setFunctions )
     {
 	    $setFunctions = false;
+    }
+    else if( "--filters" == $arg )
+    {
+        $setFilters = true;
+    }
+    else if( $setFilters )
+    {
+	    $setFilters = false;
     }
     else
     {

--- a/twig-gettext-extractor
+++ b/twig-gettext-extractor
@@ -39,6 +39,17 @@ $twig->addExtension(new Symfony\Bridge\Twig\Extension\FormExtension(
     )
 ));
 // You can add more extensions here.
+$twig->addFunction(new \Twig_SimpleFunction('formLabel', true));
+$twig->addFunction(new \Twig_SimpleFunction('formInput', true));
+$twig->addFunction(new \Twig_SimpleFunction('formElementErrors', true));
+$twig->addFunction(new \Twig_SimpleFunction('formCaptcha', true));
+$twig->addFunction(new \Twig_SimpleFunction('formHidden', true));
+$twig->addFunction(new \Twig_SimpleFunction('doctype', true));
+$twig->addFunction(new \Twig_SimpleFunction('headTitle', true));
+$twig->addFunction(new \Twig_SimpleFunction('headMeta', true));
+$twig->addFunction(new \Twig_SimpleFunction('headLink', true));
+$twig->addFunction(new \Twig_SimpleFunction('headScript', true));
+$twig->addFunction(new \Twig_SimpleFunction('OptIn', true));
 
 array_shift($_SERVER['argv']);
 $addTemplate = false;

--- a/twig-gettext-extractor
+++ b/twig-gettext-extractor
@@ -36,7 +36,7 @@ $twig->addExtension(new Symfony\Bridge\Twig\Extension\TranslationExtension(
     new Symfony\Component\Translation\Translator(null)
 ));
 
-$chain    = new Twig_Loader_Chain( [] );
+$chain    = new Twig_Loader_Chain([]);
 $renderer = new ZfcTwig\View\TwigRenderer(
     new Zend\View\View, 
     $chain, 
@@ -70,27 +70,62 @@ $twig->addFunction(new \Twig_SimpleFunction('headMeta', true));
 $twig->addFunction(new \Twig_SimpleFunction('headStyle', true));
 $twig->addFunction(new \Twig_SimpleFunction('headScript', true));
 $twig->addFunction(new \Twig_SimpleFunction('headLink', true));
-$twig->addFunction(new \Twig_SimpleFunction('OptIn', true));
-$twig->addFunction(new \Twig_SimpleFunction('InviteEmailHeader', true));
-$twig->addFunction(new \Twig_SimpleFunction('InviteEmailFooter', true));
 $twig->addFunction(new \Twig_SimpleFunction('inlineScript', true));
-$twig->addFunction(new \Twig_SimpleFunction('EmeButtonMenu', true));
 $twig->addFunction(new \Twig_SimpleFunction('layout', true));
 $twig->addFunction(new \Twig_SimpleFunction('recaptcha', true));
 
-
-
+$setFunctions = false;
 array_shift($_SERVER['argv']);
-$addTemplate = false;
+foreach ($_SERVER['argv'] as $arg)
+{
+    if( "--functions" == $arg )
+    {
+        $setFunctions = true;
+    }
+    else if( $setFunctions )
+    {
+        foreach( explode(",", $arg ) as $fn )
+            $twig->addFunction(new \Twig_SimpleFunction($fn,true));
+	    $setFunctions = false;
+    }
+}
 
+
+
+
+$addTemplate = false;
+$setExecutable = false;
 $extractor = new Twig\Gettext\Extractor($twig);
 
-foreach ($_SERVER['argv'] as $arg) {
-    if ('--files' == $arg) {
+foreach ($_SERVER['argv'] as $arg)
+{
+    if ('--files' == $arg)
+    {
         $addTemplate = true;
-    } else if ($addTemplate) {
+    }
+    else if ($addTemplate)
+    {
         $extractor->addTemplate(getcwd().DIRECTORY_SEPARATOR.$arg);
-    } else {
+    }
+    else if( "--exec" == $arg )
+    {
+        $setExecutable = true;
+    }
+    else if( $setExecutable )
+    {
+        $extractor->setExecutable( $arg );
+        $setExecutable = false;
+    }
+    else if( "--functions" == $arg )
+    {
+        $setFunctions = true;
+    }
+    else if( $setFunctions )
+    {
+	    $setFunctions = false;
+    }
+    else
+    {
         $extractor->addGettextParameter($arg);
     }
 }

--- a/twig-gettext-extractor
+++ b/twig-gettext-extractor
@@ -48,25 +48,6 @@ array_shift($_SERVER['argv']);
 
 $setFunctions = false;
 $setFilters = false;
-foreach ($_SERVER['argv'] as $arg) {
-    if ('--functions' === $arg) {
-        $setFunctions = true;
-    } else if ($setFunctions) {
-        foreach (explode(',', $arg) as $functionName) {
-            $twig->addFunction(new \Twig_SimpleFunction($functionName, true));
-        }
-        $setFunctions = false;
-    } else if ('--filters' === $arg) {
-        $setFilters = true;
-    } else if ($setFilters) {
-        foreach (explode(',', $arg) as $filterName) {
-            $twig->addFilter(new \Twig_SimpleFilter($filterName, true));
-        }
-        $setFilters = false;
-    }
-}
-
-
 $addTemplate = false;
 $setExecutable = false;
 
@@ -85,10 +66,16 @@ foreach ($_SERVER['argv'] as $arg) {
     } else if ('--functions' === $arg) {
         $setFunctions = true;
     } else if ($setFunctions) {
+        foreach (explode(',', $arg) as $functionName) {
+            $twig->addFunction(new \Twig_SimpleFunction($functionName, true));
+        }
         $setFunctions = false;
     } else if ('--filters' === $arg) {
         $setFilters = true;
     } else if ($setFilters) {
+        foreach (explode(',', $arg) as $filterName) {
+            $twig->addFilter(new \Twig_SimpleFilter($filterName, true));
+        }
         $setFilters = false;
     } else {
         $extractor->addGettextParameter($arg);

--- a/twig-gettext-extractor
+++ b/twig-gettext-extractor
@@ -69,6 +69,8 @@ $twig->addFunction(new \Twig_SimpleFunction('headMeta', true));
 $twig->addFunction(new \Twig_SimpleFunction('headLink', true));
 $twig->addFunction(new \Twig_SimpleFunction('headScript', true));
 $twig->addFunction(new \Twig_SimpleFunction('OptIn', true));
+$twig->addFunction(new \Twig_SimpleFunction('InviteEmailHeader', true));
+$twig->addFunction(new \Twig_SimpleFunction('InviteEmailFooter', true));
 
 
 array_shift($_SERVER['argv']);


### PR DESCRIPTION
We've been using the extractor successfully across a good breath of projects, but find that each product we develop has individual needs for stubs on the filter and function level.  We also test across different platforms, so the executable isn't always in path.

This PR allows you to stub functions and filters via command line.  It also allows you to specify the location of the gettext executable via command line as well.

Thank you for considering this PR.